### PR TITLE
[requirements] `pytz` is required on Ubuntu

### DIFF
--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,12 +1,12 @@
 name: Sort Imports with isort
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the ~~master~~ django branch
+# events but only for the ~~master~~ pelican branch
 on:
   push:
     branches: [ pelican ]
-  pull_request:
-    branches: [ pelican ]
+  # pull_request:
+  #   branches: [ pelican ]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,6 @@ typogrify
 # sub-dependencies; minimums for security
 pillow >= 10.0.1
 jinja2 >= 3.1.6
+
+# required for Ubuntu (GitHub Actions) builds
+pytz; sys_platform=="linux"


### PR DESCRIPTION
fixes issue caused by #457
c.f. https://github.com/dArignac/pelican-extended-sitemap/pull/18